### PR TITLE
fix google-auth version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setuptools.setup(
     python_requires='>=3.6',
     package_dir={'': 'src'},
     install_requires=[
+        'google-auth==1.21.3',
         'kubernetes>=10.0.1',
         'robotframework>=3.2.2'
     ],


### PR DESCRIPTION
Seems that new version of google-auth==1.22.0 breaks our build. Fixing into last woprking one: 1.21.3