### PR TITLE
Porting fix for cert validation bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## In progress
 
+
+### Added
 - Kubeconfig context support [#36](https://github.com/devopsspiral/KubeLibrary/pull/36) by [@m-wcislo](https://github.com/m-wcislo)
 - Keyword for getting secrets [#31](https://github.com/devopsspiral/KubeLibrary/pull/31 )by [@Nilsty](https://github.com/Nilsty)
 - Keyword for cluster healthcheck [#40](https://github.com/devopsspiral/KubeLibrary/pull/40) by [@satish-nubolab](https://github.com/satish-nubolab)
@@ -14,6 +16,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Keyword for list cronjob [#48](https://github.com/devopsspiral/KubeLibrary/pull/48) by [@satish-nubolab](https://github.com/satish-nubolab)
 - Keyword for list daemonset [#50](https://github.com/devopsspiral/KubeLibrary/pull/50) by [@satish-nubolab](https://github.com/satish-nubolab)
 - Keyword for CustomObjectsApi [#54](https://github.com/devopsspiral/KubeLibrary/pull/54) by [@mika-b](https://github.com/mika-b)
+
+### Fixed
+- Fix for cert validation disabling not being possible for all api clients [#61](https://github.com/devopsspiral/KubeLibrary/pull/61) by [@m-wcislo](https://github.com/m-wcislo)
 
 ## [0.3.0] - 2021-02-01
 

--- a/src/KubeLibrary/KubeLibrary.py
+++ b/src/KubeLibrary/KubeLibrary.py
@@ -66,6 +66,7 @@ class KubeLibrary(object):
         - ``cert_validation``:
           Default True. Can be set to False for self-signed certificates.
         """
+        self.cert_validation = cert_validation
         if incluster:
             try:
                 config.load_incluster_config()
@@ -78,15 +79,17 @@ class KubeLibrary(object):
             except TypeError:
                 logger.error('Neither KUBECONFIG nor ~/.kube/config available.')
 
-        self.v1 = client.CoreV1Api()
-        self.extensionsv1beta1 = client.ExtensionsV1beta1Api()
-        self.batchv1 = client.BatchV1Api()
-        self.appsv1 = client.AppsV1Api()
-        self.batchv1_beta1 = client.BatchV1beta1Api()
-        self.custom_object = client.CustomObjectsApi()
+        self.add_api('v1', client.CoreV1Api)
+        self.add_api('extensionsv1beta1', client.ExtensionsV1beta1Api)
+        self.add_api('batchv1', client.BatchV1Api)
+        self.add_api('appsv1', client.AppsV1Api)
+        self.add_api('batchv1_beta1', client.BatchV1beta1Api)
+        self.add_api('custom_object', client.CustomObjectsApi)
 
-        if not cert_validation:
-            self.v1.api_client.rest_client.pool_manager.connection_pool_kw['cert_reqs'] = ssl.CERT_NONE
+    def add_api(self, reference, class_name):
+        self.__dict__[reference] = class_name()
+        if not self.cert_validation:
+            self.__dict__[reference].api_client.rest_client.pool_manager.connection_pool_kw['cert_reqs'] = ssl.CERT_NONE
 
     def k8s_api_ping(self):
         """Performs GET on /api/v1/ for simple check of API availability.

--- a/test/test_KubeLibrary.py
+++ b/test/test_KubeLibrary.py
@@ -2,6 +2,7 @@
 import json
 import mock
 import re
+import ssl
 import unittest
 from KubeLibrary import KubeLibrary
 from kubernetes.config.config_exception import ConfigException

--- a/test/test_KubeLibrary.py
+++ b/test/test_KubeLibrary.py
@@ -87,6 +87,8 @@ def mock_list_node_info(watch=False, label_selector=""):
 
 class TestKubeLibrary(unittest.TestCase):
 
+    apis = ('v1', 'extensionsv1beta1', 'batchv1', 'appsv1',)
+
     def test_KubeLibrary_inits_from_kubeconfig(self):
         KubeLibrary(kube_config='test/resources/k3d')
 
@@ -96,6 +98,19 @@ class TestKubeLibrary(unittest.TestCase):
     def test_KubeLibrary_fails_for_wrong_context(self):
         kl = KubeLibrary(kube_config='test/resources/multiple_context')
         self.assertRaises(ConfigException, kl.reload_config, kube_config='test/resources/multiple_context', context='k3d-k3d-cluster2-wrong')
+
+    def test_inits_all_api_clients(self):
+        kl = KubeLibrary(kube_config='test/resources/k3d')
+        self.assertIsNotNone(kl.v1)
+        self.assertIsNotNone(kl.extensionsv1beta1)
+        self.assertIsNotNone(kl.batchv1)
+        self.assertIsNotNone(kl.appsv1)
+
+    def test_KubeLibrary_inits_without_cert_validation(self):
+        kl = KubeLibrary(kube_config='test/resources/k3d', cert_validation=False)
+        for api in TestKubeLibrary.apis:
+            target = getattr(kl, api)
+            self.assertEqual(target.api_client.rest_client.pool_manager.connection_pool_kw['cert_reqs'], ssl.CERT_NONE)
 
     def test_KubeLibrary_inits_without_cert_validation(self):
         KubeLibrary(kube_config='test/resources/k3d', cert_validation=False)

--- a/test/test_KubeLibrary.py
+++ b/test/test_KubeLibrary.py
@@ -113,9 +113,6 @@ class TestKubeLibrary(unittest.TestCase):
             target = getattr(kl, api)
             self.assertEqual(target.api_client.rest_client.pool_manager.connection_pool_kw['cert_reqs'], ssl.CERT_NONE)
 
-    def test_KubeLibrary_inits_without_cert_validation(self):
-        KubeLibrary(kube_config='test/resources/k3d', cert_validation=False)
-
     def test_filter_pods_names(self):
         pods_items = mock_list_namespaced_pod('default')
         kl = KubeLibrary(kube_config='test/resources/k3d')

--- a/test/test_KubeLibrary.py
+++ b/test/test_KubeLibrary.py
@@ -88,7 +88,8 @@ def mock_list_node_info(watch=False, label_selector=""):
 
 class TestKubeLibrary(unittest.TestCase):
 
-    apis = ('v1', 'extensionsv1beta1', 'batchv1', 'appsv1',)
+    apis = ('v1', 'extensionsv1beta1', 'batchv1', 'appsv1', 'batchv1_beta1',
+            'custom_object')
 
     def test_KubeLibrary_inits_from_kubeconfig(self):
         KubeLibrary(kube_config='test/resources/k3d')
@@ -102,10 +103,8 @@ class TestKubeLibrary(unittest.TestCase):
 
     def test_inits_all_api_clients(self):
         kl = KubeLibrary(kube_config='test/resources/k3d')
-        self.assertIsNotNone(kl.v1)
-        self.assertIsNotNone(kl.extensionsv1beta1)
-        self.assertIsNotNone(kl.batchv1)
-        self.assertIsNotNone(kl.appsv1)
+        for api in TestKubeLibrary.apis:
+            self.assertIsNotNone(getattr(kl, api))
 
     def test_KubeLibrary_inits_without_cert_validation(self):
         kl = KubeLibrary(kube_config='test/resources/k3d', cert_validation=False)


### PR DESCRIPTION
Cert validation could be disabled only for single api client. Changed the way clients are defined so it is smarter.

Before merge following needs to be applied:

- [x] PR entry added in CHANGELOG.md in **In progress** section
- [x] Coverage threshold increased in [.coveragerc](https://github.com/devopsspiral/KubeLibrary/blob/master/.coveragerc) if new coverage is higher than actual, see the lint-and-coverage step in CI
```
fail_under = 67
```
