### PR TITLE
Update KubeLibrary.py: Keywords added to get replicaset

### DIFF
--- a/src/KubeLibrary/KubeLibrary.py
+++ b/src/KubeLibrary/KubeLibrary.py
@@ -280,6 +280,7 @@ class KubeLibrary(object):
         r = re.compile(name_pattern)
         deployments = [item for item in ret.items if r.match(item.metadata.name)]
         return deployments
+    
     def get_replicasets_in_namespace(self, name_pattern, namespace, label_selector=""):
         """Gets replicasets matching pattern in given namespace.
 
@@ -296,6 +297,7 @@ class KubeLibrary(object):
         r = re.compile(name_pattern)
         replicasets = [item for item in ret.items if r.match(item.metadata.name)]
         return replicasets
+    
     def get_jobs_in_namespace(self, name_pattern, namespace, label_selector=""):
         """Gets jobs matching pattern in given namespace.
 

--- a/src/KubeLibrary/KubeLibrary.py
+++ b/src/KubeLibrary/KubeLibrary.py
@@ -280,7 +280,24 @@ class KubeLibrary(object):
         r = re.compile(name_pattern)
         deployments = [item for item in ret.items if r.match(item.metadata.name)]
         return deployments
+    
+    def get_replicasets_in_namespace(self, name_pattern, namespace, label_selector=""):
+        """Gets replicasets matching pattern in given namespace.
 
+        Can be optionally filtered by label. e.g. label_selector=label_key=label_value
+
+        Returns list of replicasets.
+
+        - ``name_pattern``:
+          replicaset name pattern to check
+        - ``namespace``:
+          Namespace to check
+        """
+        ret = self.appsv1.list_namespaced_replica_set(namespace, watch=False, label_selector=label_selector)
+        r = re.compile(name_pattern)
+        replicasets = [item for item in ret.items if r.match(item.metadata.name)]
+        return replicasets
+    
     def get_jobs_in_namespace(self, name_pattern, namespace, label_selector=""):
         """Gets jobs matching pattern in given namespace.
 

--- a/src/KubeLibrary/KubeLibrary.py
+++ b/src/KubeLibrary/KubeLibrary.py
@@ -280,7 +280,6 @@ class KubeLibrary(object):
         r = re.compile(name_pattern)
         deployments = [item for item in ret.items if r.match(item.metadata.name)]
         return deployments
-    
     def get_replicasets_in_namespace(self, name_pattern, namespace, label_selector=""):
         """Gets replicasets matching pattern in given namespace.
 
@@ -297,7 +296,6 @@ class KubeLibrary(object):
         r = re.compile(name_pattern)
         replicasets = [item for item in ret.items if r.match(item.metadata.name)]
         return replicasets
-    
     def get_jobs_in_namespace(self, name_pattern, namespace, label_selector=""):
         """Gets jobs matching pattern in given namespace.
 


### PR DESCRIPTION
Added Keywords to get replicasets in namespace

\<Remember to add meaningful title\>

\<Short description of the PR\>

Fixes #82 

Before merge following needs to be applied:
- [ ] At least one example testcase added in testcases/
- [ ] Library Documentation regenerated according to [Generate docs](https://github.com/devopsspiral/KubeLibrary#generate-docs)
- [ ] PR entry added in CHANGELOG.md in **In progress** section
- [ ] All new testcases tagged as **prerelease** along other tags to exclude it from execution until released on PyPI
- [ ] Coverage threshold increased in [.coveragerc](https://github.com/devopsspiral/KubeLibrary/blob/master/.coveragerc) if new coverage is higher than actual, see the lint-and-coverage step in CI
```
fail_under = 67
```
