### PR TITLE
Generate keyword documentation without a kubernetes cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,9 +168,13 @@ For development cluster you can use k3s/k3d as described in [DevOps spiral artic
 ### Generate docs
 
 ```
-# To generate keyword documentation a connection
-# to a cluster is not necessary. Skip to load a 
-# cluster configuration.
-export INIT_FOR_LIBDOC_ONLY=1
-python -m robot.libdoc src/KubeLibrary/KubeLibrary.py docs/index.html
+(
+    # To generate keyword documentation a connection
+    # to a cluster is not necessary. Skip to load a
+    # cluster configuration.
+    #
+    # Set the variable local for the libdoc call only
+    export INIT_FOR_LIBDOC_ONLY=1
+    python -m robot.libdoc src/KubeLibrary/KubeLibrary.py docs/index.html
+)
 ```

--- a/README.md
+++ b/README.md
@@ -168,5 +168,9 @@ For development cluster you can use k3s/k3d as described in [DevOps spiral artic
 ### Generate docs
 
 ```
+# To generate keyword documentation a connection
+# to a cluster is not necessary. Skip to load a 
+# cluster configuration.
+export INIT_FOR_LIBDOC_ONLY=1
 python -m robot.libdoc src/KubeLibrary/KubeLibrary.py docs/index.html
 ```

--- a/src/KubeLibrary/KubeLibrary.py
+++ b/src/KubeLibrary/KubeLibrary.py
@@ -4,6 +4,7 @@ import ssl
 import urllib3
 
 from kubernetes import client, config, dynamic
+from os import environ
 from robot.api import logger
 from robot.api.deco import library
 from string import digits, ascii_lowercase
@@ -85,7 +86,13 @@ class KubeLibrary:
           Default False. Indicates if used from within k8s cluster. Overrides kubeconfig.
         - ``cert_validation``:
           Default True. Can be set to False for self-signed certificates.
+
+        Environment variables:
+        - INIT_FOR_LIBDOC_ONLY:
+          Set to '1' to generate keyword documentation and skip to load a kube config..
         """
+        if "1" == environ.get('INIT_FOR_LIBDOC_ONLY', "0"):
+            return
         self.reload_config(kube_config=kube_config, context=context, api_url=api_url, bearer_token=bearer_token,
                            ca_cert=ca_cert, incluster=incluster, cert_validation=cert_validation)
 


### PR DESCRIPTION
For a Docker image with Robotframework and additional
libraries we generate the keyword documentation for all
included Robot libraries with robotframework-hub-static
and robotframework-hub-bli.

For this a generic way to run libdoc is necessary and
library specific initialization would break the generic
approach.

So far robotframework-kubelibrary was the only library
where the generation of keyword documentation failed
and required access to a Kubernetes cluster.

This patch evaluates environment variable INIT_FOR_LIBDOC_ONLY.
When this variable is set to 1, the keyword documentation can
be created without the need to access a cluster.
