### PR TITLE
publish v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## In progress
 
+## [0.6.2] - 2022-02-25
+
+### Fixed
+- Fix the kubernetes lib version (21.7.0) to still support extension/v1beta1 (ingress)
+
 ## [0.6.1] - 2022-01-27
 ### Changed
 - Refactored setup.py & requirements, moved library scope to GLOBAL, sperated exceptions [#101](https://github.com/devopsspiral/KubeLibrary/pull/101) by [@MarcinMaciaszek](https://github.com/MarcinMaciaszek)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 google-auth==1.21.3
-kubernetes==21.7.0
+kubernetes>=10.0.1,<=21.7.0
 robotframework>=3.2.2
 urllib3-mock>=0.3.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 google-auth==1.21.3
-kubernetes>=10.0.1
+kubernetes==21.7.0
 robotframework>=3.2.2
 urllib3-mock>=0.3.3

--- a/src/KubeLibrary/version.py
+++ b/src/KubeLibrary/version.py
@@ -1,1 +1,1 @@
-version = "0.6.1"
+version = "0.6.2"


### PR DESCRIPTION
Fixes kubernetes library version to handle drop of extension/v1beta1 (ingress) in 22.0.0 version