### PR TITLE
Add proxy settings for k8s client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## In progress
+- Add setting proxy from HTTP_PROXY environment for k8s client 
+- Add setting noproxy from NO_PROXY environment for k8s client 
 
 ## [0.8.0] - 2022-10-27
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## In progress
-- Add setting proxy from HTTP_PROXY environment for k8s client 
-- Add setting noproxy from NO_PROXY environment for k8s client 
+- Add proxy configuration fetched from `HTTP_PROXY` or `http_proxy` environment variable
 
 ## [0.8.0] - 2022-10-27
 ### Added

--- a/README.md
+++ b/README.md
@@ -134,6 +134,14 @@ kind delete cluster --name kind-cluster-2
 
 Keywords documentation can be found in docs/.
 
+## Proxy configuration
+
+To access cluster via proxy set `http_proxy` or `HTTP_PROXY` environment variable. 
+
+In similar way you can set `no_proxy` or `NO_PROXY` variable to specify hosts that should be excluded from proxying.
+
+**IMPORTANT:** Lowercase environment variables have higher priority than uppercase
+
 ## Further reading
 
 [DevOps spiral article on KubeLibrary](https://devopsspiral.com/articles/k8s/robotframework-kubelibrary/)

--- a/src/KubeLibrary/KubeLibrary.py
+++ b/src/KubeLibrary/KubeLibrary.py
@@ -234,8 +234,6 @@ class KubeLibrary:
         Environment variables:
         - HTTP_PROXY:
           Proxy URL
-        - NO_PROXY:
-          Bypass proxy for host in the no_proxy list.
         """
         self.api_client = None
         self.cert_validation = cert_validation
@@ -263,8 +261,7 @@ class KubeLibrary:
         if not self.api_client:
             self.api_client = client.ApiClient(configuration=client.Configuration().get_default_copy())
 
-        self.api_client.configuration.proxy = environ.get('HTTP_PROXY')
-        self.api_client.configuration.no_proxy = environ.get('NO_PROXY')
+        self.api_client.configuration.proxy = environ.get('http_proxy') or environ.get('HTTP_PROXY')
 
         self._add_api('v1', client.CoreV1Api)
         self._add_api('networkingv1api', client.NetworkingV1Api)

--- a/src/KubeLibrary/KubeLibrary.py
+++ b/src/KubeLibrary/KubeLibrary.py
@@ -230,6 +230,12 @@ class KubeLibrary:
           Default False. Indicates if used from within k8s cluster. Overrides kubeconfig.
         - ``cert_validation``:
           Default True. Can be set to False for self-signed certificates.
+
+        Environment variables:
+        - HTTP_PROXY:
+          Proxy URL
+        - NO_PROXY:
+          Bypass proxy for host in the no_proxy list.
         """
         self.api_client = None
         self.cert_validation = cert_validation
@@ -256,6 +262,10 @@ class KubeLibrary:
 
         if not self.api_client:
             self.api_client = client.ApiClient(configuration=client.Configuration().get_default_copy())
+
+        self.api_client.configuration.proxy = environ.get('HTTP_PROXY')
+        self.api_client.configuration.no_proxy = environ.get('NO_PROXY')
+
         self._add_api('v1', client.CoreV1Api)
         self._add_api('networkingv1api', client.NetworkingV1Api)
         self._add_api('batchv1', client.BatchV1Api)


### PR DESCRIPTION
Hi!

I added proxy and noproxy settings to k8s client configuration. Both of them are fetched from environment variables.

- [ ] [**N/A**] At least one example testcase added in testcases/ 
- [ ] [**No changes**] Library Documentation regenerated according to [Generate docs](https://github.com/devopsspiral/KubeLibrary#generate-docs) 
- [x] PR entry added in CHANGELOG.md in **In progress** section
- [ ] [**N/A**] All new testcases tagged as **prerelease** along other tags to exclude it from execution until released on PyPI
- [x] Coverage threshold increased in [.coveragerc](https://github.com/devopsspiral/KubeLibrary/blob/master/.coveragerc) if new coverage is higher than actual, see the lint-and-coverage step in CI
```
fail_under = 86
```
