### PR TITLE
feat: upgrade google-auth dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-google-auth==1.21.3
+google-auth>=2.5.0
 kubernetes>=21.7.0
 robotframework>=3.2.2
 urllib3-mock>=0.3.3


### PR DESCRIPTION
The version used is really old and it causes hard constraints on tools we may use such as gsutil

\<Remember to add meaningful title\>

\<Short description of the PR\>

Fixes #\<issue number\>

Before merge following needs to be applied:
- [ ] At least one example testcase added in testcases/
- [ ] Library Documentation regenerated according to [Generate docs](https://github.com/devopsspiral/KubeLibrary#generate-docs)
- [ ] PR entry added in CHANGELOG.md in **In progress** section
- [ ] All new testcases tagged as **prerelease** along other tags to exclude it from execution until released on PyPI
- [ ] Coverage threshold increased in [.coveragerc](https://github.com/devopsspiral/KubeLibrary/blob/master/.coveragerc) if new coverage is higher than actual, see the lint-and-coverage step in CI
```
fail_under = 86
```
