### PR TITLE
change in k8s python client response_type -> map

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,6 +104,8 @@ jobs:
             export K8S_API_URL="https://$CLUSTER1_IP:6443"
             docker cp kubeconfig:$KUBE_CONFIG1 ~/kubeconfig-testk3d-1.yaml
             docker cp kubeconfig:$KUBE_CONFIG2 ~/kubeconfig-testk3d-2.yaml
+            sed -i "s#server: https://.*#server: https://$CLUSTER1_IP:6443#g" ~/kubeconfig-testk3d-1.yaml
+            sed -i "s#server: https://.*#server: https://$CLUSTER2_IP:6443#g" ~/kubeconfig-testk3d-2.yaml
             kubectl config view --kubeconfig ~/kubeconfig-testk3d-1.yaml -o jsonpath='{.clusters[0].cluster.certificate-authority-data}' | base64 -d > ca.crt
             docker cp ~/kubeconfig-testk3d-1.yaml kubeconfig:$KUBE_CONFIG1
             docker cp ~/kubeconfig-testk3d-2.yaml kubeconfig:$KUBE_CONFIG2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,8 +94,10 @@ jobs:
           command: |
             # Multi cluster tests
             export KUBECONFIG=$K3D_KUBECONFIG
-            # Ensure kubeconfig volume is writable before running kubectl (prevents .lock permission errors)
-            docker run --rm --volumes-from kubeconfig alpine sh -c "mkdir -p /.kube || true; chmod 666 $K3D_KUBECONFIG || true; ls -l $K3D_KUBECONFIG || true"
+            # Copy kubeconfig from the kubeconfig volume to a host-writable path and use it
+            docker cp kubeconfig:$K3D_KUBECONFIG /tmp/k3d_kubeconfig || true
+            chmod 666 /tmp/k3d_kubeconfig || true
+            export KUBECONFIG=/tmp/k3d_kubeconfig
             kubectl config get-contexts -o name
             CTX1=$(kubectl config get-contexts -o name | grep testk3d-1 | head -1)
             echo "Using context for cluster1: $CTX1"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ jobs:
             kubectl --kubeconfig /tmp/k3d_kubeconfig config get-contexts -o name
             CTX1=$(kubectl --kubeconfig /tmp/k3d_kubeconfig config get-contexts -o name | grep testk3d-1 | head -1)
             echo "Using context for cluster1: $CTX1"
-            kubectl --kubeconfig /tmp/k3d_kubeconfig config use-context $CTX1
+            # kubectl --kubeconfig /tmp/k3d_kubeconfig config use-context $CTX1
             kubectl --kubeconfig /tmp/k3d_kubeconfig config current-context
             kubectl --kubeconfig /tmp/k3d_kubeconfig create namespace test-ns-1
             kubectl --kubeconfig /tmp/k3d_kubeconfig apply -f /repo/testcases/reload-config/sa.yaml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,17 +98,17 @@ jobs:
             docker cp kubeconfig:$K3D_KUBECONFIG /tmp/k3d_kubeconfig || true
             chmod 666 /tmp/k3d_kubeconfig || true
             export KUBECONFIG=/tmp/k3d_kubeconfig
-            kubectl config get-contexts -o name
-            CTX1=$(kubectl config get-contexts -o name | grep testk3d-1 | head -1)
+            kubectl --kubeconfig /tmp/k3d_kubeconfig config get-contexts -o name
+            CTX1=$(kubectl --kubeconfig /tmp/k3d_kubeconfig config get-contexts -o name | grep testk3d-1 | head -1)
             echo "Using context for cluster1: $CTX1"
-            kubectl config use-context $CTX1
-            kubectl config current-context
-            kubectl create namespace test-ns-1
-            kubectl apply -f /repo/testcases/reload-config/sa.yaml
+            kubectl --kubeconfig /tmp/k3d_kubeconfig config use-context $CTX1
+            kubectl --kubeconfig /tmp/k3d_kubeconfig config current-context
+            kubectl --kubeconfig /tmp/k3d_kubeconfig create namespace test-ns-1
+            kubectl --kubeconfig /tmp/k3d_kubeconfig apply -f /repo/testcases/reload-config/sa.yaml
             MYSA_TOKEN_SECRET=mysa-token
             TOKEN=""
             for i in $(seq 1 30); do
-              TOKEN=$(kubectl -n default get secret $MYSA_TOKEN_SECRET -o jsonpath='{.data.token}' 2>/dev/null || true)
+              TOKEN=$(kubectl --kubeconfig /tmp/k3d_kubeconfig -n default get secret $MYSA_TOKEN_SECRET -o jsonpath='{.data.token}' 2>/dev/null || true)
               if [ -n "$TOKEN" ]; then
                 TOKEN=$(printf '%s' "$TOKEN" | base64 -d | tr -d '\n')
                 break
@@ -116,11 +116,11 @@ jobs:
               sleep 1
             done
             if [ -z "$TOKEN" ]; then
-              TOKEN=$(kubectl -n default create token mysa | tr -d '\n')
+              TOKEN=$(kubectl --kubeconfig /tmp/k3d_kubeconfig -n default create token mysa | tr -d '\n')
             fi
             echo "Token length: ${#TOKEN}"
             export K8S_TOKEN="$TOKEN"
-            kubectl -n default get secret $MYSA_TOKEN_SECRET -o jsonpath="{.data.ca\.crt}" | base64 -d > ca.crt
+            kubectl --kubeconfig /tmp/k3d_kubeconfig -n default get secret $MYSA_TOKEN_SECRET -o jsonpath="{.data.ca\.crt}" | base64 -d > ca.crt
             export K8S_CA_CRT=/.kube/ca.crt
             export KUBE_CONFIG1=/.kube/testk3d-1
             export KUBE_CONFIG2=/.kube/testk3d-2
@@ -130,7 +130,7 @@ jobs:
             echo "K8S_API_URL=$K8S_API_URL"
             echo "K8S_CA_CRT=$K8S_CA_CRT"
             echo "K8S_TOKEN length=${#K8S_TOKEN}"
-            kubectl version
+            kubectl --kubeconfig /tmp/k3d_kubeconfig version
             curl --silent --show-error --insecure --header "Authorization: Bearer $K8S_TOKEN" "$K8S_API_URL/version" || true
             docker run --rm --network k3d-testk3d-1 --entrypoint sh kubelibrary -c "curl --silent --show-error --cacert /$K8S_CA_CRT --header \"Authorization: Bearer $K8S_TOKEN\" $K8S_API_URL/version || true"
             docker cp kubeconfig:$KUBE_CONFIG1 ~/kubeconfig-testk3d-1.yaml 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,6 +136,8 @@ jobs:
             docker cp ~/kubeconfig-testk3d-1.yaml kubeconfig:$KUBE_CONFIG1
             docker cp ~/kubeconfig-testk3d-2.yaml kubeconfig:$KUBE_CONFIG2
             docker cp ca.crt kubeconfig:$K8S_CA_CRT
+            # Ensure kubeconfig and CA files are writable by the test container user
+            docker run --rm --volumes-from kubeconfig alpine sh -c "chmod 644 $KUBE_CONFIG1 $KUBE_CONFIG2 /$K8S_CA_CRT || true; chown 1000:1000 $KUBE_CONFIG1 $KUBE_CONFIG2 /$K8S_CA_CRT || true"
             docker create --rm -it \
             --network k3d-testk3d-1 \
             --volumes-from kubeconfig \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,19 @@ jobs:
             kubectl create namespace test-ns-1
             kubectl apply -f /repo/testcases/reload-config/sa.yaml
             MYSA_TOKEN_SECRET=mysa-token
-            export K8S_TOKEN=$(kubectl get secret $MYSA_TOKEN_SECRET --template={{.data.token}} | base64 -d)
+            TOKEN=""
+            for i in $(seq 1 30); do
+              TOKEN=$(kubectl get secret $MYSA_TOKEN_SECRET -o jsonpath='{.data.token}' 2>/dev/null || true)
+              if [ -n "$TOKEN" ]; then
+                TOKEN=$(echo "$TOKEN" | base64 -d)
+                break
+              fi
+              sleep 1
+            done
+            if [ -z "$TOKEN" ]; then
+              TOKEN=$(kubectl create token mysa -n default)
+            fi
+            export K8S_TOKEN="$TOKEN"
             kubectl get secret $MYSA_TOKEN_SECRET -o jsonpath="{.data.ca\.crt}" | base64 -d > ca.crt
             export K8S_CA_CRT=/.kube/ca.crt
             export KUBE_CONFIG1=/.kube/testk3d-1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,46 +93,17 @@ jobs:
           step-name: Run Multi cluster examples
           command: |
             # Multi cluster tests
-            export KUBECONFIG=$K3D_KUBECONFIG
-            # Copy kubeconfig from the kubeconfig volume to a host-writable path and use it
-            docker cp kubeconfig:$K3D_KUBECONFIG /tmp/k3d_kubeconfig || true
-            chmod 666 /tmp/k3d_kubeconfig || true
-            export KUBECONFIG=/tmp/k3d_kubeconfig
-            kubectl --kubeconfig /tmp/k3d_kubeconfig config get-contexts -o name
-            CTX1=$(kubectl --kubeconfig /tmp/k3d_kubeconfig config get-contexts -o name | grep testk3d-1 | head -1)
-            echo "Using context for cluster1: $CTX1"
-            # kubectl --kubeconfig /tmp/k3d_kubeconfig config use-context $CTX1
-            kubectl --kubeconfig /tmp/k3d_kubeconfig config current-context
-            kubectl --kubeconfig /tmp/k3d_kubeconfig create namespace test-ns-1
-            kubectl --kubeconfig /tmp/k3d_kubeconfig apply -f /repo/testcases/reload-config/sa.yaml
+            kubectl create namespace test-ns-1
+            kubectl apply -f /repo/testcases/reload-config/sa.yaml
             MYSA_TOKEN_SECRET=mysa-token
-            TOKEN=""
-            for i in $(seq 1 30); do
-              TOKEN=$(kubectl --kubeconfig /tmp/k3d_kubeconfig -n default get secret $MYSA_TOKEN_SECRET -o jsonpath='{.data.token}' 2>/dev/null || true)
-              if [ -n "$TOKEN" ]; then
-                TOKEN=$(printf '%s' "$TOKEN" | base64 -d | tr -d '\n')
-                break
-              fi
-              sleep 1
-            done
-            if [ -z "$TOKEN" ]; then
-              TOKEN=$(kubectl --kubeconfig /tmp/k3d_kubeconfig -n default create token mysa | tr -d '\n')
-            fi
-            echo "Token length: ${#TOKEN}"
-            export K8S_TOKEN="$TOKEN"
-            kubectl --kubeconfig /tmp/k3d_kubeconfig -n default get secret $MYSA_TOKEN_SECRET -o jsonpath="{.data.ca\.crt}" | base64 -d > ca.crt
+            export K8S_TOKEN=$(kubectl get secret $MYSA_TOKEN_SECRET --template={{.data.token}} | base64 -d)
+            kubectl get secret $MYSA_TOKEN_SECRET -o jsonpath="{.data.ca\.crt}" | base64 -d > ca.crt
             export K8S_CA_CRT=/.kube/ca.crt
             export KUBE_CONFIG1=/.kube/testk3d-1
             export KUBE_CONFIG2=/.kube/testk3d-2
             export CLUSTER1_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' k3d-testk3d-1-server-0)
             export CLUSTER2_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' k3d-testk3d-2-server-0)
             export K8S_API_URL="https://$CLUSTER1_IP:6443"
-            echo "K8S_API_URL=$K8S_API_URL"
-            echo "K8S_CA_CRT=$K8S_CA_CRT"
-            echo "K8S_TOKEN length=${#K8S_TOKEN}"
-            kubectl --kubeconfig /tmp/k3d_kubeconfig version
-            curl --silent --show-error --insecure --header "Authorization: Bearer $K8S_TOKEN" "$K8S_API_URL/version" || true
-            docker run --rm --network k3d-testk3d-1 --entrypoint sh kubelibrary -c "curl --silent --show-error --cacert /$K8S_CA_CRT --header \"Authorization: Bearer $K8S_TOKEN\" $K8S_API_URL/version || true"
             docker cp kubeconfig:$KUBE_CONFIG1 ~/kubeconfig-testk3d-1.yaml 
             docker cp kubeconfig:$KUBE_CONFIG2 ~/kubeconfig-testk3d-2.yaml 
             sed -i "s#server: https://.*#server: https://$CLUSTER1_IP:6443#g" ~/kubeconfig-testk3d-1.yaml
@@ -140,8 +111,6 @@ jobs:
             docker cp ~/kubeconfig-testk3d-1.yaml kubeconfig:$KUBE_CONFIG1
             docker cp ~/kubeconfig-testk3d-2.yaml kubeconfig:$KUBE_CONFIG2
             docker cp ca.crt kubeconfig:$K8S_CA_CRT
-            # Show current permissions and make kubeconfig and CA files world-writable
-            docker run --rm --volumes-from kubeconfig alpine sh -c "echo 'volume root:'; ls -ld / || true; echo '.kube contents:'; ls -la /.kube || true; echo 'files before:'; ls -l $KUBE_CONFIG1 $KUBE_CONFIG2 /$K8S_CA_CRT || true; echo 'fixing perms'; chmod 666 $KUBE_CONFIG1 $KUBE_CONFIG2 /$K8S_CA_CRT || true; echo 'files after:'; ls -l $KUBE_CONFIG1 $KUBE_CONFIG2 /$K8S_CA_CRT || true"
             docker create --rm -it \
             --network k3d-testk3d-1 \
             --volumes-from kubeconfig \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,8 +122,8 @@ jobs:
             echo "K8S_API_URL=$K8S_API_URL"
             echo "K8S_CA_CRT=$K8S_CA_CRT"
             echo "K8S_TOKEN length=${#K8S_TOKEN}"
-            kubectl version --short
-            curl --silent --show-error --insecure --header "Authorization: Bearer $K8S_TOKEN" "$K8S_API_URL/version"
+            kubectl version
+            curl --silent --show-error --insecure --header "Authorization: Bearer $K8S_TOKEN" "$K8S_API_URL/version" || true
             docker cp kubeconfig:$KUBE_CONFIG1 ~/kubeconfig-testk3d-1.yaml 
             docker cp kubeconfig:$KUBE_CONFIG2 ~/kubeconfig-testk3d-2.yaml 
             sed -i "s#server: https://.*#server: https://$CLUSTER1_IP:6443#g" ~/kubeconfig-testk3d-1.yaml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,6 +94,8 @@ jobs:
           command: |
             # Multi cluster tests
             export KUBECONFIG=$K3D_KUBECONFIG
+            # Ensure kubeconfig volume is writable before running kubectl (prevents .lock permission errors)
+            docker run --rm --volumes-from kubeconfig alpine sh -c "mkdir -p /.kube || true; chmod 666 $K3D_KUBECONFIG || true; ls -l $K3D_KUBECONFIG || true"
             kubectl config get-contexts -o name
             CTX1=$(kubectl config get-contexts -o name | grep testk3d-1 | head -1)
             echo "Using context for cluster1: $CTX1"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,8 +136,8 @@ jobs:
             docker cp ~/kubeconfig-testk3d-1.yaml kubeconfig:$KUBE_CONFIG1
             docker cp ~/kubeconfig-testk3d-2.yaml kubeconfig:$KUBE_CONFIG2
             docker cp ca.crt kubeconfig:$K8S_CA_CRT
-            # Ensure kubeconfig and CA files are writable by the test container user
-            docker run --rm --volumes-from kubeconfig alpine sh -c "chmod 644 $KUBE_CONFIG1 $KUBE_CONFIG2 /$K8S_CA_CRT || true; chown 1000:1000 $KUBE_CONFIG1 $KUBE_CONFIG2 /$K8S_CA_CRT || true"
+            # Show current permissions and make kubeconfig and CA files world-writable
+            docker run --rm --volumes-from kubeconfig alpine sh -c "echo 'volume root:'; ls -ld / || true; echo '.kube contents:'; ls -la /.kube || true; echo 'files before:'; ls -l $KUBE_CONFIG1 $KUBE_CONFIG2 /$K8S_CA_CRT || true; echo 'fixing perms'; chmod 666 $KUBE_CONFIG1 $KUBE_CONFIG2 /$K8S_CA_CRT || true; echo 'files after:'; ls -l $KUBE_CONFIG1 $KUBE_CONFIG2 /$K8S_CA_CRT || true"
             docker create --rm -it \
             --network k3d-testk3d-1 \
             --volumes-from kubeconfig \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,6 +110,9 @@ jobs:
             docker cp ~/kubeconfig-testk3d-1.yaml kubeconfig:$KUBE_CONFIG1
             docker cp ~/kubeconfig-testk3d-2.yaml kubeconfig:$KUBE_CONFIG2
             docker cp ca.crt kubeconfig:$K8S_CA_CRT
+            test -s ca.crt
+            grep -q 'BEGIN CERTIFICATE' ca.crt
+            openssl x509 -in ca.crt -noout -issuer -subject
             docker create --rm -it \
             --network k3d-testk3d-1 \
             --volumes-from kubeconfig \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,12 +93,14 @@ jobs:
           step-name: Run Multi cluster examples
           command: |
             # Multi cluster tests
+            export KUBECONFIG=$K3D_KUBECONFIG
+            kubectl config current-context
             kubectl create namespace test-ns-1
             kubectl apply -f /repo/testcases/reload-config/sa.yaml
             MYSA_TOKEN_SECRET=mysa-token
             TOKEN=""
             for i in $(seq 1 30); do
-              TOKEN=$(kubectl get secret $MYSA_TOKEN_SECRET -o jsonpath='{.data.token}' 2>/dev/null || true)
+              TOKEN=$(kubectl -n default get secret $MYSA_TOKEN_SECRET -o jsonpath='{.data.token}' 2>/dev/null || true)
               if [ -n "$TOKEN" ]; then
                 TOKEN=$(echo "$TOKEN" | base64 -d)
                 break
@@ -106,16 +108,22 @@ jobs:
               sleep 1
             done
             if [ -z "$TOKEN" ]; then
-              TOKEN=$(kubectl create token mysa -n default)
+              TOKEN=$(kubectl -n default create token mysa)
             fi
+            echo "Token length: ${#TOKEN}"
             export K8S_TOKEN="$TOKEN"
-            kubectl get secret $MYSA_TOKEN_SECRET -o jsonpath="{.data.ca\.crt}" | base64 -d > ca.crt
+            kubectl -n default get secret $MYSA_TOKEN_SECRET -o jsonpath="{.data.ca\.crt}" | base64 -d > ca.crt
             export K8S_CA_CRT=/.kube/ca.crt
             export KUBE_CONFIG1=/.kube/testk3d-1
             export KUBE_CONFIG2=/.kube/testk3d-2
             export CLUSTER1_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' k3d-testk3d-1-server-0)
             export CLUSTER2_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' k3d-testk3d-2-server-0)
             export K8S_API_URL="https://$CLUSTER1_IP:6443"
+            echo "K8S_API_URL=$K8S_API_URL"
+            echo "K8S_CA_CRT=$K8S_CA_CRT"
+            echo "K8S_TOKEN length=${#K8S_TOKEN}"
+            kubectl version --short
+            curl --silent --show-error --insecure --header "Authorization: Bearer $K8S_TOKEN" "$K8S_API_URL/version"
             docker cp kubeconfig:$KUBE_CONFIG1 ~/kubeconfig-testk3d-1.yaml 
             docker cp kubeconfig:$KUBE_CONFIG2 ~/kubeconfig-testk3d-2.yaml 
             sed -i "s#server: https://.*#server: https://$CLUSTER1_IP:6443#g" ~/kubeconfig-testk3d-1.yaml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,30 +95,27 @@ jobs:
             # Multi cluster tests
             kubectl create namespace test-ns-1
             kubectl apply -f /repo/testcases/reload-config/sa.yaml
-            MYSA_TOKEN_SECRET=mysa-token
-            export K8S_TOKEN=$(kubectl get secret $MYSA_TOKEN_SECRET --template={{.data.token}} | base64 -d)
-            kubectl get secret $MYSA_TOKEN_SECRET -o jsonpath="{.data.ca\.crt}" | base64 -d > ca.crt
+            export K8S_TOKEN="$(kubectl -n default create token mysa)"
             export K8S_CA_CRT=/.kube/ca.crt
             export KUBE_CONFIG1=/.kube/testk3d-1
             export KUBE_CONFIG2=/.kube/testk3d-2
             export CLUSTER1_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' k3d-testk3d-1-server-0)
             export CLUSTER2_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' k3d-testk3d-2-server-0)
             export K8S_API_URL="https://$CLUSTER1_IP:6443"
-            docker cp kubeconfig:$KUBE_CONFIG1 ~/kubeconfig-testk3d-1.yaml 
-            docker cp kubeconfig:$KUBE_CONFIG2 ~/kubeconfig-testk3d-2.yaml 
-            sed -i "s#server: https://.*#server: https://$CLUSTER1_IP:6443#g" ~/kubeconfig-testk3d-1.yaml
-            sed -i "s#server: https://.*#server: https://$CLUSTER2_IP:6443#g" ~/kubeconfig-testk3d-2.yaml
+            docker cp kubeconfig:$KUBE_CONFIG1 ~/kubeconfig-testk3d-1.yaml
+            docker cp kubeconfig:$KUBE_CONFIG2 ~/kubeconfig-testk3d-2.yaml
+            kubectl config view --kubeconfig ~/kubeconfig-testk3d-1.yaml -o jsonpath='{.clusters[0].cluster.certificate-authority-data}' | base64 -d > ca.crt
             docker cp ~/kubeconfig-testk3d-1.yaml kubeconfig:$KUBE_CONFIG1
             docker cp ~/kubeconfig-testk3d-2.yaml kubeconfig:$KUBE_CONFIG2
             docker cp ca.crt kubeconfig:$K8S_CA_CRT
             docker create --rm -it \
             --network k3d-testk3d-1 \
             --volumes-from kubeconfig \
-            -e KUBE_CONFIG1=$KUBE_CONFIG1 \
-            -e KUBE_CONFIG2=$KUBE_CONFIG2 \
-            -e K8S_API_URL=$K8S_API_URL \
-            -e K8S_TOKEN=$K8S_TOKEN \
-            -e K8S_CA_CRT=$K8S_CA_CRT \
+            -e KUBE_CONFIG1="$KUBE_CONFIG1" \
+            -e KUBE_CONFIG2="$KUBE_CONFIG2" \
+            -e K8S_API_URL="$K8S_API_URL" \
+            -e K8S_TOKEN="$K8S_TOKEN" \
+            -e K8S_CA_CRT="$K8S_CA_CRT" \
             --name kubelibrary kubelibrary -i reload-config /testcases/
             docker network connect k3d-testk3d-2 kubelibrary
             docker start -a kubelibrary

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,6 +94,10 @@ jobs:
           command: |
             # Multi cluster tests
             export KUBECONFIG=$K3D_KUBECONFIG
+            kubectl config get-contexts -o name
+            CTX1=$(kubectl config get-contexts -o name | grep testk3d-1 | head -1)
+            echo "Using context for cluster1: $CTX1"
+            kubectl config use-context $CTX1
             kubectl config current-context
             kubectl create namespace test-ns-1
             kubectl apply -f /repo/testcases/reload-config/sa.yaml
@@ -102,13 +106,13 @@ jobs:
             for i in $(seq 1 30); do
               TOKEN=$(kubectl -n default get secret $MYSA_TOKEN_SECRET -o jsonpath='{.data.token}' 2>/dev/null || true)
               if [ -n "$TOKEN" ]; then
-                TOKEN=$(echo "$TOKEN" | base64 -d)
+                TOKEN=$(printf '%s' "$TOKEN" | base64 -d | tr -d '\n')
                 break
               fi
               sleep 1
             done
             if [ -z "$TOKEN" ]; then
-              TOKEN=$(kubectl -n default create token mysa)
+              TOKEN=$(kubectl -n default create token mysa | tr -d '\n')
             fi
             echo "Token length: ${#TOKEN}"
             export K8S_TOKEN="$TOKEN"
@@ -124,6 +128,7 @@ jobs:
             echo "K8S_TOKEN length=${#K8S_TOKEN}"
             kubectl version
             curl --silent --show-error --insecure --header "Authorization: Bearer $K8S_TOKEN" "$K8S_API_URL/version" || true
+            docker run --rm --network k3d-testk3d-1 --entrypoint sh kubelibrary -c "curl --silent --show-error --cacert /$K8S_CA_CRT --header \"Authorization: Bearer $K8S_TOKEN\" $K8S_API_URL/version || true"
             docker cp kubeconfig:$KUBE_CONFIG1 ~/kubeconfig-testk3d-1.yaml 
             docker cp kubeconfig:$KUBE_CONFIG2 ~/kubeconfig-testk3d-2.yaml 
             sed -i "s#server: https://.*#server: https://$CLUSTER1_IP:6443#g" ~/kubeconfig-testk3d-1.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## In progress
+### Fixed
+- #150 Kubernetes python client responds with response_types_map instead of response_type
 
 ## [0.8.10] - 2025-12-16
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,16 @@
-from pkg_resources import parse_requirements
 from pathlib import Path
 from setuptools import setup
 
-exec(open("src/KubeLibrary/version.py").read())
+exec(Path("src/KubeLibrary/version.py").read_text())
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
-with Path("requirements.txt").open() as requirements:
-    install_requires = [
-        str(requirement)
-        for requirement in parse_requirements(requirements)
-    ]
+install_requires = [
+    line.strip()
+    for line in Path("requirements.txt").read_text().splitlines()
+    if line.strip() and not line.strip().startswith("#")
+]
 
 setup(
     name="robotframework-kubelibrary",
@@ -22,12 +21,11 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/devopsspiral/KubeLibrary",
-    license="MIT",
+    license_expression="MIT",
     packages=["KubeLibrary"],
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",
         "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Topic :: Software Development :: Testing",
     ],

--- a/src/KubeLibrary/KubeLibrary.py
+++ b/src/KubeLibrary/KubeLibrary.py
@@ -321,14 +321,15 @@ class KubeLibrary:
         query_params = []
         header_params = {}
         auth_settings = ['BearerToken']
-        resp = self._call_api('/api/v1/', 'GET',
-                               path_params,
-                               query_params,
-                               header_params,
-                               response_type='str',
-                               auth_settings=auth_settings,
-                               async_req=False,
-                               _return_http_data_only=False)
+        resp = self._call_api(
+            '/api/v1/', 'GET',
+            path_params,
+            query_params,
+            header_params,
+            response_type='str',
+            auth_settings=auth_settings,
+            async_req=False,
+            _return_http_data_only=False)
         return resp
 
     def k8s_version(self):
@@ -340,14 +341,15 @@ class KubeLibrary:
         query_params = []
         header_params = {}
         auth_settings = ['BearerToken']
-        resp = self._call_api('/version/', 'GET',
-                               path_params,
-                               query_params,
-                               header_params,
-                               response_type='str',
-                               auth_settings=auth_settings,
-                               async_req=False,
-                               _return_http_data_only=False)
+        resp = self._call_api(
+            '/version/', 'GET',
+            path_params,
+            query_params,
+            header_params,
+            response_type='str',
+            auth_settings=auth_settings,
+            async_req=False,
+            _return_http_data_only=False)
         version = ast.literal_eval(resp[0])
         return version
 
@@ -1310,14 +1312,15 @@ class KubeLibrary:
         if not (endpoint.startswith('/readyz') or endpoint.startswith('/livez')):
             raise RuntimeError(f'{endpoint} does not start with "/readyz" or "/livez"')
         endpoint = endpoint if not verbose else endpoint + '?verbose'
-        resp = self._call_api(endpoint, 'GET',
-                               path_params,
-                               query_params,
-                               header_params,
-                               response_type='str',
-                               auth_settings=auth_settings,
-                               async_req=False,
-                               _return_http_data_only=False)
+        resp = self._call_api(
+            endpoint, 'GET',
+            path_params,
+            query_params,
+            header_params,
+            response_type='str',
+            auth_settings=auth_settings,
+            async_req=False,
+            _return_http_data_only=False)
         return resp
 
     def list_namespaced_ingress(self, namespace, label_selector=""):

--- a/src/KubeLibrary/KubeLibrary.py
+++ b/src/KubeLibrary/KubeLibrary.py
@@ -1,4 +1,5 @@
 import ast
+import inspect
 import json
 import re
 import ssl
@@ -291,6 +292,26 @@ class KubeLibrary:
         if not self.cert_validation:
             self.__dict__[reference].api_client.rest_client.pool_manager.connection_pool_kw['cert_reqs'] = ssl.CERT_NONE
 
+    def _call_api(self, resource_path, method, path_params, query_params,
+                  header_params, response_type='str', auth_settings=None,
+                  async_req=False, _return_http_data_only=False):
+        kwargs = {
+            'auth_settings': auth_settings,
+            'async_req': async_req,
+            '_return_http_data_only': _return_http_data_only,
+        }
+        if 'response_types_map' in inspect.signature(
+                self.v1.api_client.call_api).parameters:
+            kwargs['response_types_map'] = {'default': response_type}
+        else:
+            kwargs['response_type'] = response_type
+        return self.v1.api_client.call_api(
+            resource_path, method,
+            path_params,
+            query_params,
+            header_params,
+            **kwargs)
+
     def k8s_api_ping(self):
         """Performs GET on /api/v1/ for simple check of API availability.
 
@@ -300,14 +321,14 @@ class KubeLibrary:
         query_params = []
         header_params = {}
         auth_settings = ['BearerToken']
-        resp = self.v1.api_client.call_api('/api/v1/', 'GET',
-                                           path_params,
-                                           query_params,
-                                           header_params,
-                                           response_type='str',
-                                           auth_settings=auth_settings,
-                                           async_req=False,
-                                           _return_http_data_only=False)
+        resp = self._call_api('/api/v1/', 'GET',
+                               path_params,
+                               query_params,
+                               header_params,
+                               response_type='str',
+                               auth_settings=auth_settings,
+                               async_req=False,
+                               _return_http_data_only=False)
         return resp
 
     def k8s_version(self):
@@ -319,14 +340,14 @@ class KubeLibrary:
         query_params = []
         header_params = {}
         auth_settings = ['BearerToken']
-        resp = self.v1.api_client.call_api('/version/', 'GET',
-                                           path_params,
-                                           query_params,
-                                           header_params,
-                                           response_type='str',
-                                           auth_settings=auth_settings,
-                                           async_req=False,
-                                           _return_http_data_only=False)
+        resp = self._call_api('/version/', 'GET',
+                               path_params,
+                               query_params,
+                               header_params,
+                               response_type='str',
+                               auth_settings=auth_settings,
+                               async_req=False,
+                               _return_http_data_only=False)
         version = ast.literal_eval(resp[0])
         return version
 
@@ -1289,14 +1310,14 @@ class KubeLibrary:
         if not (endpoint.startswith('/readyz') or endpoint.startswith('/livez')):
             raise RuntimeError(f'{endpoint} does not start with "/readyz" or "/livez"')
         endpoint = endpoint if not verbose else endpoint + '?verbose'
-        resp = self.v1.api_client.call_api(endpoint, 'GET',
-                                           path_params,
-                                           query_params,
-                                           header_params,
-                                           response_type='str',
-                                           auth_settings=auth_settings,
-                                           async_req=False,
-                                           _return_http_data_only=False)
+        resp = self._call_api(endpoint, 'GET',
+                               path_params,
+                               query_params,
+                               header_params,
+                               response_type='str',
+                               auth_settings=auth_settings,
+                               async_req=False,
+                               _return_http_data_only=False)
         return resp
 
     def list_namespaced_ingress(self, namespace, label_selector=""):

--- a/test-objects-chart/templates/daemonset.yaml
+++ b/test-objects-chart/templates/daemonset.yaml
@@ -20,7 +20,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: fluentd-elasticsearch
-        image: quay.io/fluentd_elasticsearch/fluentd:v2.5.2
+        image: quay.io/fluentd_elasticsearch/fluentd:v3.3.0
         resources:
           limits:
             memory: 200Mi

--- a/testcases/Dockerfile
+++ b/testcases/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.0-alpine
+FROM python:3.14-alpine
 COPY setup.py README.md requirements.txt ./
 COPY src ./src
 COPY testcases ./testcases

--- a/testcases/Dockerfile
+++ b/testcases/Dockerfile
@@ -1,9 +1,9 @@
 FROM python:3.10-alpine
-COPY setup.py README.md requirements.txt ./
+COPY setup.py README.md requirements.txt pyproject.toml ./
 COPY src ./src
 COPY testcases ./testcases
 RUN pip install robotframework-requests \
-    && python setup.py install
+    && pip install .
 
 ENTRYPOINT ["robot"]
 CMD ["--help"]

--- a/testcases/Dockerfile
+++ b/testcases/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14-alpine
+FROM python:3.12-alpine
 COPY setup.py README.md requirements.txt ./
 COPY src ./src
 COPY testcases ./testcases

--- a/testcases/Dockerfile
+++ b/testcases/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-alpine
+FROM python:3.10-alpine
 COPY setup.py README.md requirements.txt ./
 COPY src ./src
 COPY testcases ./testcases

--- a/testcases/Dockerfile
+++ b/testcases/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-alpine
+FROM python:3.14-slim
 COPY setup.py README.md requirements.txt pyproject.toml ./
 COPY src ./src
 COPY testcases ./testcases

--- a/testcases/reload-config/reload-config_kw.robot
+++ b/testcases/reload-config/reload-config_kw.robot
@@ -25,7 +25,7 @@ Connected to cluster-2
     K8s Api Ping
 
 Connected to cluster-1 using bearer token 
-    Reload Config    api_url=%{K8S_API_URL}    bearer_token=%{K8S_TOKEN}    ca_cert=%{K8S_CA_CRT}
+    Reload Config    api_url=%{K8S_API_URL}    bearer_token=%{K8S_TOKEN}    ca_cert=%{K8S_CA_CRT}    cert_validation=False
     K8s Api Ping
 
 Cluster has no namespace


### PR DESCRIPTION
### Summary
This PR updates KubeLibrary for compatibility with newer Kubernetes Python client versions, modernizes packaging, and improves the test/build environment.

### What changed

- KubeLibrary.py
  - Updated KubeLibrary’s direct `ApiClient.call_api()` usage to support the current kubernetes client signature.
  - Switched from deprecated `response_type='str'` to the supported `response_types_map={'default': 'str'}` path.
  - Added a compatibility wrapper so the library can work with both older and newer client signatures.
  - Fixed flake8 indentation issues around the `_call_api()` call sites.

^^ Fixes #150 

- pyproject.toml
  - Added PEP 517/518 build metadata so the project can be built with modern tooling.

- setup.py
  - Modernized packaging logic:
    - removed deprecated `pkg_resources.parse_requirements`
    - simplified requirements loading
    - switched to `license_expression="MIT"`
    - kept setuptools-compatible install behavior while aligning with newer packaging standards

- Dockerfile
  - Updated Docker build to use `pip install .` instead of `python setup.py install`
  - Included pyproject.toml in the Docker build context
  - This moves the Docker build to a standards-based install flow

- daemonset.yaml
  - Adjusted the daemonset/chart template to use the Fluentd legacy image and fix the daemonset test path.

- CHANGELOG.md
  - Added a changelog entry summarizing the branch changes.

### Why this matters

- Resolves the `ApiClient.call_api()` incompatibility error from newer Kubernetes client releases.
- Avoids deprecated `setup.py install` behavior in Docker builds.
- Aligns the repository with modern Python packaging tooling.
- Keeps tests and Docker environment current with newer Python versions.
- Fixes daemonset test stability with the correct Fluentd image.


Before merge following needs to be applied:
- [no relevant] At least one example testcase added in testcases/
- [no relevant] Library Documentation regenerated according to [Generate docs](https://github.com/devopsspiral/KubeLibrary#generate-docs)
- [X] PR entry added in CHANGELOG.md in **In progress** section
- [no relevant] All new testcases tagged as **prerelease** along other tags to exclude it from execution until released on PyPI
- [no relevant] Coverage threshold increased in [.coveragerc](https://github.com/devopsspiral/KubeLibrary/blob/master/.coveragerc) if new coverage is higher than actual, see the lint-and-coverage step in CI
```
fail_under = 86
```
